### PR TITLE
Refactor(series): Optimize supersedes update by prefetching related projects

### DIFF
--- a/patchwork/api/series.py
+++ b/patchwork/api/series.py
@@ -34,7 +34,7 @@ class SeriesSerializer(BaseHyperlinkedModelSerializer):
     )
     supersedes = HyperlinkedRelatedField(
         view_name='api-series-detail',
-        queryset=Series.objects.all(),
+        queryset=Series.objects.select_related('project').all(),
         required=False,
         many=True,
     )


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

This PR refactors the way the `supersedes` field is defined. This change reduces the number of queries made in the `update` by prefetching the projects related to the series. The current implementation makes M + 2N queries in an `update`, where M is a constant (33) and N is the number of elements in supersedes. The changes reduce the number of queries to M + N.

<!-- Describe what your PR does here, change log, etc -->


## Progress
- [x] Refactor the `supersedes` field in series.

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->


## How to test it
Clone the repository. Enter a Series Details page using the API URL: `{BASE_URL}/api/1.4/series/{SERIES_ID}/`. Use the forms at the bottom of the page to update supersedes. Use the right sidebar DjDT to check the number of queries used.

<!-- Describe how the reviewers can test your feature. -->

## Visual reference
In this example, 10 elements were updated in the supersedes field.
Before | After
:-:|:-:
<img width="350" alt="before" src="https://github.com/user-attachments/assets/db9e5ae2-486b-4f07-8b62-baf8ea746c5a"> | <img width="350" alt="after" src="https://github.com/user-attachments/assets/5b5be493-4132-40cd-aa24-8a3635eef444">
-->




<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
