### PR TITLE
[FIX] Restrict note visibility 

### DIFF
--- a/patchwork/tests/views/test_patch.py
+++ b/patchwork/tests/views/test_patch.py
@@ -248,7 +248,10 @@ class PatchViewTest(TestCase):
         self.assertRedirects(response, redirect_url)
 
     def test_show_maintainer_note(self):
-        patch = create_patch()
+        project = create_project()
+        user_default = create_user(project)
+        user_maintainer = create_maintainer(project)
+        patch = create_patch(project=project)
         note = create_patch_comment(patch=patch, msgid='')
         requested_url = reverse(
             'patch-detail',
@@ -257,6 +260,20 @@ class PatchViewTest(TestCase):
                 'msgid': patch.encoded_msgid,
             },
         )
+
+        # No authentication
+        response = self.client.get(requested_url)
+        self.assertNotIn('# Maintainer Note'.encode('utf-8'), response.content)
+        self.assertNotIn(note.content.encode('utf-8'), response.content)
+
+        # Auth with default user
+        self.client.login(username=user_default.username, password=user_default.username)
+        response = self.client.get(requested_url)
+        self.assertNotIn('# Maintainer Note'.encode('utf-8'), response.content)
+        self.assertNotIn(note.content.encode('utf-8'), response.content)
+
+        # Auth with maintainer user
+        self.client.login(username=user_maintainer.username, password=user_maintainer.username)
         response = self.client.get(requested_url)
         self.assertIn('# Maintainer Note'.encode('utf-8'), response.content)
         self.assertIn(note.content.encode('utf-8'), response.content)

--- a/patchwork/views/cover.py
+++ b/patchwork/views/cover.py
@@ -58,8 +58,10 @@ def cover_detail(request, project_id, msgid):
         handle_post_maintainer_note(cover, request)
     )
 
+    if is_maintainer:
+        context['note'] = note
+
     context['comments'] = comments
-    context['note'] = note
     context['is_maintainer'] = is_maintainer
     context['create_note_form'] = create_note_form
     context['edit_note_form'] = edit_note_form

--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -165,7 +165,9 @@ def patch_detail(request, project_id, msgid):
         related_same_project = []
         related_different_project = []
 
-    context['note'] = note
+    if is_maintainer:
+        context['note'] = note
+
     context['comments'] = comments
     context['checks'] = Patch.filter_unique_checks(
         patch.check_set.all().select_related('user'),


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

This PR updates note visualization. Notes should only be visible to maintainers or superusers, but the current version of the code shows notes to every user, even if they are not authenticated. This PR also updates the tests according to the view changes.


<!-- Describe what your PR does here, change log, etc -->


## Progress
- [x] Update patch and cover views to include notes in the context only if `is_maintainer` is true.
- [x] Update tests according to the changes in the views.

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it
Clone the repository. Run the project. Log in as a project maintainer. Create a note in a patch. Check that this note is visible to you. Log out and log in as a superuser. Check that the note is also visible to you. Log out and log in as a user who is neither a maintainer nor a superuser. Check that the note is not visible to you. Run the tests; check that they all pass.

<!-- Describe how the reviewers can test your feature. -->

## Visual reference
Visual reference for a non-maintainer user:
Before | After
:-:|:-:
<img width="350" alt="before" src="https://github.com/user-attachments/assets/d37ca4e6-11de-4861-b5b0-5d7434f0bc94"> | <img width="350" alt="after" src="https://github.com/user-attachments/assets/a299f040-2f6c-4a86-8e4a-3badf3dca61c">


<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
