### PR TITLE
[FIX] Grant maintainer privileges to superuser and  fix attention set handling

### DIFF
--- a/patchwork/api/patch.py
+++ b/patchwork/api/patch.py
@@ -427,6 +427,14 @@ class PatchDetail(RetrieveUpdateAPIView):
             obj.project in request.user.profile.maintainer_projects.all()
             or request.user.is_superuser
         )
+        non_attention_set_keys = [
+            key for key in request.data if key != 'attention_set'
+        ]
+
+        if non_attention_set_keys and not is_maintainer:
+            raise PermissionDenied(
+                detail='You do not have permission to edit patch properties.'
+            )
 
         if 'attention_set' in request.data and request.method in ('PATCH',):
             attention_set = request.data.get('attention_set', None)

--- a/patchwork/api/patch.py
+++ b/patchwork/api/patch.py
@@ -425,6 +425,7 @@ class PatchDetail(RetrieveUpdateAPIView):
         req_user_id = request.user.id
         is_maintainer = request.user.is_authenticated and (
             obj.project in request.user.profile.maintainer_projects.all()
+            or request.user.is_superuser
         )
 
         if 'attention_set' in request.data and request.method in ('PATCH',):

--- a/patchwork/templatetags/patch.py
+++ b/patchwork/templatetags/patch.py
@@ -79,7 +79,7 @@ def patch_commit_display(patch):
 
 @register.filter(name='patch_interest')
 def patch_interest(patch):
-    reviews = patch.attention_set.count()
+    reviews = patch.patchattentionset_set.filter(removed=False).count()
     review_title = (
         f'has {reviews} interested reviewers'
         if reviews > 0

--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -90,9 +90,7 @@ def patch_detail(request, project_id, msgid):
         elif action in ['add-interest', 'remove-interest']:
             if request.user.is_authenticated:
                 if action == 'add-interest':
-                    PatchAttentionSet.objects.get_or_create(
-                        patch=patch, user=request.user
-                    )
+                    PatchAttentionSet.objects.upsert(patch, [request.user.id])
                     message = (
                         'You have declared interest in reviewing this patch'
                     )

--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -66,6 +66,7 @@ def patch_detail(request, project_id, msgid):
     is_maintainer = (
         request.user.is_authenticated
         and project in request.user.profile.maintainer_projects.all()
+        or request.user.is_superuser
     )
 
     form = None


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description
This PR grants maintainer privileges to superusers to ensure consistency with other PRs. It also fixes two bugs: the 'Review Interest' column in the patch list template was showing all users who had been added to the attention set, even if they were later removed; and the patch details view would cause an error if a user who was removed from the attention set tried to declare interest again. Additionally, it fixes problems in the partial update implementation used to change the attention set, which was not checking if a non-maintainer user was changing only the attention set field, causing the tests to break.

<!-- Describe what your PR does here, change log, etc -->

## Progress
- [x] Grant maintainer privileges to superusers in the API.
- [x] Grant maintainer privileges to superusers in the view.
- [x] Fix bug where excluded users were still shown in the patch list template.
- [x] Fix bug preventing a removed user from declaring interest again in the patch details view.
- [x] Fix partial update implementation to check if a non-maintainer user is changing only the attention set.

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it
Log in as a normal user and declare interest in a patch. Log in as a different user with superuser status and navigate to the patch details page. Remove the first user's interest in the patch, check it works. Repeat the process using the API. Once the user's interest has been removed, log back in as the normal user and try to declare interest in the same patch again, check it works.

<!-- Describe how the reviewers can test your feature. -->


<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
